### PR TITLE
Init Lib Module branch for IPV6 and IPV4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 - docker stop mailcow-dind
 
 after_script:
-- docker tag mailcow-dind quay.io/promaethius/mailcow-dind:lib
+- docker tag mailcow-dind quay.io/promaethius/mailcow-dind:$TRAVIS_BRANCH
 - mkdir -p ~/.docker
 - |
   cat > ~/.docker/config.json << EOF
@@ -25,4 +25,4 @@ after_script:
     }
   }
   EOF
-- docker push quay.io/promaethius/mailcow-dind:lib
+- docker push quay.io/promaethius/mailcow-dind:$TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 script:
 - cd images
 - docker build -t mailcow-dind mailcow-dind
-- docker run -e HOSTNAME='example.com' -e CRON_BACKUP='* * * * * *' -e TIMEZONE='PDT' -v /home/travis/dind:/var/lib/docker -v /home/travis/mailcow:/mailcow -v /home/travis/mailcow-backup:/mailcow-backup --name mailcow-dind --privileged -d mailcow-dind
+- docker run -e HOSTNAME='example.com' -e CRON_BACKUP='* * * * * *' -e TIMEZONE='PDT' -v /home/travis/dind:/var/lib/docker -v /home/travis/mailcow:/mailcow -v /home/travis/mailcow-backup:/mailcow-backup -v /lib/modules:lib/modules --name mailcow-dind --privileged -d mailcow-dind
 - docker logs mailcow-dind -f &
 - sleep 4m
 - docker stop mailcow-dind

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 script:
 - cd images
 - docker build -t mailcow-dind mailcow-dind
-- docker run -e HOSTNAME='example.com' -e CRON_BACKUP='* * * * * *' -e TIMEZONE='PDT' -v /home/travis/dind:/var/lib/docker -v /home/travis/mailcow:/mailcow -v /home/travis/mailcow-backup:/mailcow-backup -v /lib/modules:lib/modules --name mailcow-dind --privileged -d mailcow-dind
+- docker run -e HOSTNAME='example.com' -e CRON_BACKUP='* * * * * *' -e TIMEZONE='PDT' -v /home/travis/dind:/var/lib/docker -v /home/travis/mailcow:/mailcow -v /home/travis/mailcow-backup:/mailcow-backup -v /lib/modules:/lib/modules --name mailcow-dind --privileged -d mailcow-dind
 - docker logs mailcow-dind -f &
 - sleep 4m
 - docker stop mailcow-dind

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 - docker stop mailcow-dind
 
 after_script:
-- docker tag mailcow-dind quay.io/promaethius/mailcow-dind
+- docker tag mailcow-dind quay.io/promaethius/mailcow-dind:lib
 - mkdir -p ~/.docker
 - |
   cat > ~/.docker/config.json << EOF
@@ -25,4 +25,4 @@ after_script:
     }
   }
   EOF
-- docker push quay.io/promaethius/mailcow-dind
+- docker push quay.io/promaethius/mailcow-dind:lib

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           name: mailcow-persistent
         - mountPath: /mailcow-backup
           name: mailcow-backup
+        - mountPath: /lib/modules
+          name: lib-modules
         securityContext:
           capabilities:
             privileged: true
@@ -54,3 +56,5 @@ spec:
       - name: mailcow-backup
         persistentVolumeClaim:
           claimName: mailcow-backup
+      - name: lib-modules
+        hostPath: /lib/modules


### PR DESCRIPTION
To implement IPV4 and IPV6 correctly, docker might need access to NAT and iptables through the host kernel.