### PR TITLE
Pull docker images before startup

### DIFF
--- a/images/mailcow-dind/cmd.sh
+++ b/images/mailcow-dind/cmd.sh
@@ -128,6 +128,7 @@ init_mailcow() {
 
 start_mailcow() {
   cd /mailcow
+  docker-compose pull
   docker-compose up -d
   docker-compose logs -f
 }


### PR DESCRIPTION
The container will build the images inside of the container when stopped and then started. This can be fixed be first pulling the images and then starting the container.